### PR TITLE
Default to no cover id

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -74,7 +74,7 @@
             <span class="tooltip-text">Google Drive file ID for the cover template. If left blank, no cover will be generated. The songbook generator needs to have read access to this folder to work!</span>
           </span>
         </label>
-        <input id="cover" name="cover_file_id" type="text" value="1rxn4Kl6fe-SUFqfYieb5FrxkVwHLLVPbwOXtWRGc740" />
+        <input id="cover" name="cover_file_id" type="text" value="" />
         <label for="limit" title="Maximum number of song sheets to include in the songbook">
           Limit
           <span class="tooltip">❓


### PR DESCRIPTION
Cover Id generation is currently buggy so this is a workaround to unblock testing