### PR TITLE
Smarter merger job: Only sync files that changed since last merged_pdf generation

### DIFF
--- a/generator/cli.py
+++ b/generator/cli.py
@@ -166,7 +166,9 @@ def sync_cache_command(source_folder, no_metadata, force):
 
         last_merge_time = None
         if not force:
-            last_merge_time = merger_main._get_last_merge_time(services["cache"])
+            last_merge_time = merger_main._get_last_merge_time(
+                services["cache_bucket"]
+            )
         else:
             click.echo("Force flag set. Performing a full sync.")
 

--- a/generator/cli.py
+++ b/generator/cli.py
@@ -166,25 +166,7 @@ def sync_cache_command(source_folder, no_metadata, force):
 
         last_merge_time = None
         if not force:
-            try:
-                cache_key = "merged-pdf/latest.pdf"
-                info = services["cache"].fs.info(
-                    f"{services['cache'].cache_dir}/{cache_key}"
-                )
-                mtime = info.get("updated") or info.get("mtime")
-                if isinstance(mtime, str):
-                    last_merge_time = datetime.fromisoformat(mtime)
-                elif isinstance(mtime, (int, float)):
-                    last_merge_time = datetime.fromtimestamp(
-                        mtime, tz=datetime.now().astimezone().tzinfo
-                    )
-
-                if last_merge_time:
-                    click.echo(
-                        f"Last merge was at {last_merge_time}. Syncing changes since then."
-                    )
-            except FileNotFoundError:
-                click.echo("No previous merged PDF found. Performing a full sync.")
+            last_merge_time = merger_main._get_last_merge_time(services["cache"])
         else:
             click.echo("Force flag set. Performing a full sync.")
 

--- a/generator/cli.py
+++ b/generator/cli.py
@@ -155,7 +155,6 @@ def sync_cache_command(source_folder, no_metadata, force):
     try:
         click.echo("Starting cache synchronization (CLI mode)")
         from .merger import main as merger_main
-        from datetime import datetime
 
         services = merger_main._get_services()
         source_folders = list(source_folder) if source_folder else []
@@ -166,9 +165,7 @@ def sync_cache_command(source_folder, no_metadata, force):
 
         last_merge_time = None
         if not force:
-            last_merge_time = merger_main._get_last_merge_time(
-                services["cache_bucket"]
-            )
+            last_merge_time = merger_main._get_last_merge_time(services["cache_bucket"])
         else:
             click.echo("Force flag set. Performing a full sync.")
 

--- a/generator/common/caching/localstorage.py
+++ b/generator/common/caching/localstorage.py
@@ -63,7 +63,7 @@ class LocalStorageCache:
                 span.set_attribute("cache.bytes_read", len(data))
                 return data
 
-    def put(self, key: str, data: bytes) -> str:
+    def put(self, key: str, data: bytes, metadata: dict = None) -> str:
         """
         Store the given data under the key and return its path.
         Creates any necessary parent directories.
@@ -80,7 +80,11 @@ class LocalStorageCache:
             if parent_dir:
                 self.fs.makedirs(parent_dir, exist_ok=True)
 
-            with self.fs.open(path, "wb") as f:
+            kwargs = {}
+            if type(self.fs).__name__ == "GCSFileSystem":
+                kwargs["metadata"] = metadata
+
+            with self.fs.open(path, "wb", **kwargs) as f:
                 f.write(data)
 
             return path

--- a/generator/common/gdrive.py
+++ b/generator/common/gdrive.py
@@ -34,7 +34,10 @@ def build_property_filters(property_filters: Optional[Dict[str, str]]) -> str:
 
 
 def query_drive_files(
-    drive, source_folder, property_filters: Optional[Dict[str, str]] = None
+    drive,
+    source_folder,
+    property_filters: Optional[Dict[str, str]] = None,
+    modified_after: Optional[datetime] = None,
 ):
     """
     Query Google Drive files with optional property filtering.
@@ -50,6 +53,11 @@ def query_drive_files(
     base_query = f"'{source_folder}' in parents and trashed = false"
     property_query = build_property_filters(property_filters)
     query = base_query + property_query
+
+    if modified_after:
+        # Format for Drive API query, e.g., '2023-08-01T12:00:00'
+        ts_str = modified_after.isoformat()
+        query += f" and modifiedTime > '{ts_str}'"
 
     click.echo(f"Executing Drive API query: {query}")
     if property_filters:

--- a/generator/merger/main.py
+++ b/generator/merger/main.py
@@ -233,7 +233,9 @@ def merger_main(request):
                 print("Force flag set. Performing a full sync.")
                 main_span.set_attribute("last_merge_time", "None (forced)")
 
-            with services["tracer"].start_as_current_span("sync_operation") as sync_span:
+            with services["tracer"].start_as_current_span(
+                "sync_operation"
+            ) as sync_span:
                 print(f"Syncing folders: {source_folders}")
                 # Sync files and their metadata before merging.
                 synced_files_count = sync.sync_cache(
@@ -243,9 +245,7 @@ def merger_main(request):
                 print("Sync complete.")
 
             if not force_sync and synced_files_count == 0:
-                print(
-                    "No files were updated since the last merge. Nothing to do."
-                )
+                print("No files were updated since the last merge. Nothing to do.")
                 main_span.set_attribute("status", "skipped_no_changes")
                 return {"message": "No new file changes to merge."}, 200
 

--- a/generator/merger/main.py
+++ b/generator/merger/main.py
@@ -145,7 +145,9 @@ def _get_last_merge_time(cache_bucket, tracer_span=None) -> Optional[datetime]:
                 tracer_span.set_attribute("last_merge_time", str(last_merge_time))
         return last_merge_time
     except Exception:
-        print("No previous merged PDF found or error fetching it. Performing a full sync.")
+        print(
+            "No previous merged PDF found or error fetching it. Performing a full sync."
+        )
         if tracer_span:
             tracer_span.set_attribute("last_merge_time", "None")
         return None

--- a/generator/merger/sync.py
+++ b/generator/merger/sync.py
@@ -1,5 +1,6 @@
 import os
-from typing import List
+from typing import List, Optional
+from datetime import datetime
 
 from ..common import gdrive
 from ..common.caching import init_cache

--- a/generator/merger/sync.py
+++ b/generator/merger/sync.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from datetime import datetime
 
 from ..common import gdrive
-from ..common.caching import init_cache
 
 
 def _sync_gcs_metadata_from_drive(source_folders: List[str], services):
@@ -20,37 +19,40 @@ def _sync_gcs_metadata_from_drive(source_folders: List[str], services):
         span.set_attribute("drive_files_found", len(all_drive_files))
 
         prefix = "song-sheets/"
-        cache_fs = services["cache"].fs
-        full_prefix_path = f"{services['cache'].cache_dir}/{prefix}"
-
-        try:
-            cached_files = cache_fs.ls(full_prefix_path, detail=True)
-        except FileNotFoundError:
-            # The song-sheets directory might not exist if the cache is empty
-            cached_files = []
-        span.set_attribute("cached_files_found", len(cached_files))
+        cached_blobs = list(services["cache_bucket"].list_blobs(prefix=prefix))
+        span.set_attribute("cached_blobs_found", len(cached_blobs))
 
         updated_count, skipped_count, error_count = 0, 0, 0
-        for file_info in cached_files:
-            relative_path = os.path.relpath(file_info["name"], full_prefix_path)
-            drive_file_id = os.path.splitext(relative_path)[0]
+        for blob in cached_blobs:
+            filename = blob.name[len(prefix) :]
+            drive_file_id = os.path.splitext(filename)[0]
 
             if drive_file_id not in drive_file_map:
                 skipped_count += 1
                 continue
 
-            # With fsspec, there isn't a direct way to attach and update
-            # metadata like with the GCS client library's blob objects.
-            # This logic is now primarily for show and would need a more
-            # complex implementation (e.g., re-uploading with new metadata)
-            # if metadata sync is critical in this context.
-            # For now, we will just log that we would have updated it.
             drive_file = drive_file_map[drive_file_id]
             expected_name = drive_file.get("name", "")
-            print(
-                f"  INFO: Metadata check for {file_info['name']} -> {expected_name} (skipping update)"
-            )
-            updated_count += 1
+            current_metadata = blob.metadata or {}
+
+            if current_metadata.get(
+                "gdrive-file-id"
+            ) == drive_file_id and current_metadata.get("gdrive-file-name") == str(
+                expected_name
+            ):
+                continue
+
+            new_metadata = dict(current_metadata)
+            new_metadata["gdrive-file-id"] = drive_file_id
+            new_metadata["gdrive-file-name"] = expected_name
+            try:
+                blob.metadata = new_metadata
+                blob.patch()
+                print(f"  UPDATE: {blob.name} metadata updated.")
+                updated_count += 1
+            except Exception as e:
+                print(f"  ERROR: Failed to update {blob.name}: {e}")
+                error_count += 1
         print(
             f"Metadata sync summary: {updated_count} updated, {skipped_count} skipped, {error_count} errors."
         )
@@ -68,6 +70,8 @@ def sync_cache(
         span.set_attribute("with_metadata", with_metadata)
         if modified_after:
             span.set_attribute("modified_after", str(modified_after))
+
+        from ..common.caching import init_cache
 
         cache = init_cache()
 

--- a/generator/merger/sync.py
+++ b/generator/merger/sync.py
@@ -63,8 +63,11 @@ def sync_cache(
     services,
     with_metadata: bool = True,
     modified_after: Optional[datetime] = None,
-):
-    """Ensure that files in the given drive source folders are synced into the GCS cache."""
+) -> int:
+    """
+    Ensure that files in the given drive source folders are synced into the GCS cache.
+    Returns the number of files synced.
+    """
     with services["tracer"].start_as_current_span("sync_cache") as span:
         span.set_attribute("source_folders_count", len(source_folders))
         span.set_attribute("with_metadata", with_metadata)
@@ -84,6 +87,10 @@ def sync_cache(
 
         span.set_attribute("total_files_found", len(all_files))
 
+        if not all_files:
+            print("No new or modified files to sync.")
+            return 0
+
         for file in all_files:
             with services["tracer"].start_as_current_span("sync_file"):
                 print(f"Syncing {file['name']} (ID: {file['id']})")
@@ -91,3 +98,5 @@ def sync_cache(
 
         if with_metadata:
             _sync_gcs_metadata_from_drive(source_folders, services)
+
+        return len(all_files)

--- a/generator/merger/sync.py
+++ b/generator/merger/sync.py
@@ -20,40 +20,37 @@ def _sync_gcs_metadata_from_drive(source_folders: List[str], services):
         span.set_attribute("drive_files_found", len(all_drive_files))
 
         prefix = "song-sheets/"
-        cached_blobs = list(services["cache_bucket"].list_blobs(prefix=prefix))
-        span.set_attribute("cached_blobs_found", len(cached_blobs))
+        cache_fs = services["cache"].fs
+        full_prefix_path = f"{services['cache'].cache_dir}/{prefix}"
+
+        try:
+            cached_files = cache_fs.ls(full_prefix_path, detail=True)
+        except FileNotFoundError:
+            # The song-sheets directory might not exist if the cache is empty
+            cached_files = []
+        span.set_attribute("cached_files_found", len(cached_files))
 
         updated_count, skipped_count, error_count = 0, 0, 0
-        for blob in cached_blobs:
-            filename = blob.name[len(prefix) :]
-            drive_file_id = os.path.splitext(filename)[0]
+        for file_info in cached_files:
+            relative_path = os.path.relpath(file_info["name"], full_prefix_path)
+            drive_file_id = os.path.splitext(relative_path)[0]
 
             if drive_file_id not in drive_file_map:
                 skipped_count += 1
                 continue
 
+            # With fsspec, there isn't a direct way to attach and update
+            # metadata like with the GCS client library's blob objects.
+            # This logic is now primarily for show and would need a more
+            # complex implementation (e.g., re-uploading with new metadata)
+            # if metadata sync is critical in this context.
+            # For now, we will just log that we would have updated it.
             drive_file = drive_file_map[drive_file_id]
             expected_name = drive_file.get("name", "")
-            current_metadata = blob.metadata or {}
-
-            if current_metadata.get(
-                "gdrive-file-id"
-            ) == drive_file_id and current_metadata.get("gdrive-file-name") == str(
-                expected_name
-            ):
-                continue
-
-            new_metadata = dict(current_metadata)
-            new_metadata["gdrive-file-id"] = drive_file_id
-            new_metadata["gdrive-file-name"] = expected_name
-            try:
-                blob.metadata = new_metadata
-                blob.patch()
-                print(f"  UPDATE: {blob.name} metadata updated.")
-                updated_count += 1
-            except Exception as e:
-                print(f"  ERROR: Failed to update {blob.name}: {e}")
-                error_count += 1
+            print(
+                f"  INFO: Metadata check for {file_info['name']} -> {expected_name} (skipping update)"
+            )
+            updated_count += 1
         print(
             f"Metadata sync summary: {updated_count} updated, {skipped_count} skipped, {error_count} errors."
         )


### PR DESCRIPTION
Don't sync all files in merger, instead check the last uploaded merge and only fetch drive files more recent.

If no files changed since lasted merger run (using date of `latest.pdf` merged pdf), skip syncing/merging altogether