### PR TITLE
More fixes to "Generate Songbook" job...

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  EDITIONS: '["regular", "complete"]'
+  EDITIONS: "regular complete"
 
 jobs:
   check-for-updates:
@@ -45,9 +45,8 @@ jobs:
           # If 'force' is used, build all editions
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
             echo "Force mode enabled. Building all editions."
-            cat <<EOF >> $GITHUB_OUTPUT
-            editions_to_build=${{ env.EDITIONS }}
-            EOF
+            editions_json=$(echo "${{ env.EDITIONS }}" | jq -R 'split(" ")' | jq -c '.')
+            echo "editions_to_build=${editions_json}" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -70,7 +69,7 @@ jobs:
           SOURCE_LATEST_UPDATE_TS=$(date -d "$SOURCE_LATEST_UPDATE_JSON" +%s)
           echo "Latest source file update: $(date -d @$SOURCE_LATEST_UPDATE_TS)"
 
-          for edition in $(echo '${{ env.EDITIONS }}' | jq -r '.[]'); do
+          for edition in ${{ env.EDITIONS }}; do
             DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
             GCS_DEST_LIST_JSON=$(gcloud storage ls "$DEST_PATH" --json)
             if [[ $? -ne 0 ]]; then

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -81,7 +81,7 @@ jobs:
             
             if [[ -z "$DEST_UPDATE_JSON" ]]; then
               echo "Published songbook for '$edition' not found. Adding to build queue."
-              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq ". + [\"$edition\"]")
+              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq -c ". + [\"$edition\"]")
               continue
             fi
             
@@ -90,7 +90,7 @@ jobs:
 
             if (( SOURCE_LATEST_UPDATE_TS > DEST_UPDATE_TS )); then
               echo "Source files are newer than '$edition' songbook. Adding to build queue."
-              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq ". + [\"$edition\"]")
+              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq -c ". + [\"$edition\"]")
             else
               echo "Songbook '$edition' is up to date."
             fi

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -98,7 +98,7 @@ jobs:
 
           echo "Editions to build: $FINAL_EDITIONS_JSON"
           echo "editions_to_build=$FINAL_EDITIONS_JSON" >> $GITHUB_OUTPUT
-  
+
   generate-songbook:
     name: Generate Songbook (${{ matrix.edition }})
     runs-on: ubuntu-latest
@@ -130,13 +130,13 @@ jobs:
 
     - name: Set up Cloud SDK
       run: gcloud config set project ${{ env.GCP_PROJECT_ID }}
-      
+
     - name: Trigger songbook generation
       run: |
         PAYLOAD=$(jq -n --arg edition "${{ matrix.edition }}" '{ edition: $edition }')
         echo "Triggering songbook generation with payload: $PAYLOAD"
         API_URL="https://${{ env.GCP_REGION }}-${{ env.GCP_PROJECT_ID }}.cloudfunctions.net/${{ env.API_FUNCTION_NAME }}"
-        
+
         RESPONSE=$(curl -s -f -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$API_URL")
         echo "API Response: $RESPONSE"
         JOB_ID=$(echo "$RESPONSE" | jq -r '.job_id')

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -42,59 +42,56 @@ jobs:
       - name: Check GCS modification times
         id: check
         run: |
+          EDITIONS_TO_BUILD_STR=""
           # If 'force' is used, build all editions
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
             echo "Force mode enabled. Building all editions."
-            editions_json=$(echo "${{ env.EDITIONS }}" | jq -R 'split(" ")' | jq -c '.')
-            echo "editions_to_build=${editions_json}" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+            EDITIONS_TO_BUILD_STR="${{ env.EDITIONS }}"
+          else
+            SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
 
-          EDITIONS_TO_BUILD_STR=""
-          SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
-
-          GCS_LIST_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json)
-          if [[ $? -ne 0 ]]; then
-              echo "::error::'gcloud storage ls' command failed for source path."
-              echo "Output was: $GCS_LIST_JSON"
-              exit 1
-          fi
-
-          SOURCE_LATEST_UPDATE_JSON=$(echo "$GCS_LIST_JSON" | jq -r '.[].metadata.updated' | sort -r | head -n 1)
-          if [[ -z "$SOURCE_LATEST_UPDATE_JSON" || "$SOURCE_LATEST_UPDATE_JSON" == "null" ]]; then
-            echo "No source files found in cache. Nothing to build."
-            echo "editions_to_build=[]" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          SOURCE_LATEST_UPDATE_TS=$(date -d "$SOURCE_LATEST_UPDATE_JSON" +%s)
-          echo "Latest source file update: $(date -d @$SOURCE_LATEST_UPDATE_TS)"
-
-          for edition in ${{ env.EDITIONS }}; do
-            DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
-            GCS_DEST_LIST_JSON=$(gcloud storage ls "$DEST_PATH" --json)
+            GCS_LIST_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json)
             if [[ $? -ne 0 ]]; then
-                echo "::warning::'gcloud storage ls' command failed for destination path ${DEST_PATH}. Assuming it doesn't exist."
-                echo "Output was: $GCS_DEST_LIST_JSON"
-                GCS_DEST_LIST_JSON="" # Treat as empty
+                echo "::error::'gcloud storage ls' command failed for source path."
+                echo "Output was: $GCS_LIST_JSON"
+                exit 1
             fi
-            DEST_UPDATE_JSON=$(echo "$GCS_DEST_LIST_JSON" | jq -r '.[].metadata.updated' || echo "")
-            
-            if [[ -z "$DEST_UPDATE_JSON" ]]; then
-              echo "Published songbook for '$edition' not found. Adding to build queue."
-              EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
-              continue
-            fi
-            
-            DEST_UPDATE_TS=$(date -d "$DEST_UPDATE_JSON" +%s)
-            echo "Latest '$edition' songbook published at: $(date -d @$DEST_UPDATE_TS)"
 
-            if (( SOURCE_LATEST_UPDATE_TS > DEST_UPDATE_TS )); then
-              echo "Source files are newer than '$edition' songbook. Adding to build queue."
-              EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
+            SOURCE_LATEST_UPDATE_JSON=$(echo "$GCS_LIST_JSON" | jq -r '.[].metadata.updated' | sort -r | head -n 1)
+            if [[ -z "$SOURCE_LATEST_UPDATE_JSON" || "$SOURCE_LATEST_UPDATE_JSON" == "null" ]]; then
+              echo "No source files found in cache. Nothing to build."
             else
-              echo "Songbook '$edition' is up to date."
+              SOURCE_LATEST_UPDATE_TS=$(date -d "$SOURCE_LATEST_UPDATE_JSON" +%s)
+              echo "Latest source file update: $(date -d @$SOURCE_LATEST_UPDATE_TS)"
+
+              for edition in ${{ env.EDITIONS }}; do
+                DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
+                GCS_DEST_LIST_JSON=$(gcloud storage ls "$DEST_PATH" --json)
+                if [[ $? -ne 0 ]]; then
+                    echo "::warning::'gcloud storage ls' command failed for destination path ${DEST_PATH}. Assuming it doesn't exist."
+                    echo "Output was: $GCS_DEST_LIST_JSON"
+                    GCS_DEST_LIST_JSON="" # Treat as empty
+                fi
+                DEST_UPDATE_JSON=$(echo "$GCS_DEST_LIST_JSON" | jq -r '.[].metadata.updated' || echo "")
+
+                if [[ -z "$DEST_UPDATE_JSON" ]]; then
+                  echo "Published songbook for '$edition' not found. Adding to build queue."
+                  EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
+                  continue
+                fi
+
+                DEST_UPDATE_TS=$(date -d "$DEST_UPDATE_JSON" +%s)
+                echo "Latest '$edition' songbook published at: $(date -d @$DEST_UPDATE_TS)"
+
+                if (( SOURCE_LATEST_UPDATE_TS > DEST_UPDATE_TS )); then
+                  echo "Source files are newer than '$edition' songbook. Adding to build queue."
+                  EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
+                else
+                  echo "Songbook '$edition' is up to date."
+                fi
+              done
             fi
-          done
+          fi
 
           # Convert the space-separated string to a JSON array for the output
           FINAL_EDITIONS_JSON=$(echo "${EDITIONS_TO_BUILD_STR}" | jq -R 'split(" ") | map(select(length > 0))' | jq -c '.')

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -45,7 +45,9 @@ jobs:
           # If 'force' is used, build all editions
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
             echo "Force mode enabled. Building all editions."
-            echo "editions_to_build=${{ env.EDITIONS }}" >> $GITHUB_OUTPUT
+            cat <<EOF >> $GITHUB_OUTPUT
+            editions_to_build=${{ env.EDITIONS }}
+            EOF
             exit 0
           fi
 

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -42,7 +42,6 @@ jobs:
       - name: Check GCS modification times
         id: check
         run: |
-          set -x
           # If 'force' is used, build all editions
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
             echo "Force mode enabled. Building all editions."

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -60,7 +60,7 @@ jobs:
               exit 1
           fi
 
-          SOURCE_LATEST_UPDATE_JSON=$(echo "$GCS_LIST_JSON" | jq -r '.[].updated' | sort -r | head -n 1)
+          SOURCE_LATEST_UPDATE_JSON=$(echo "$GCS_LIST_JSON" | jq -r '.[].metadata.updated' | sort -r | head -n 1)
           if [[ -z "$SOURCE_LATEST_UPDATE_JSON" || "$SOURCE_LATEST_UPDATE_JSON" == "null" ]]; then
             echo "No source files found in cache. Nothing to build."
             echo "editions_to_build=[]" >> $GITHUB_OUTPUT
@@ -77,7 +77,7 @@ jobs:
                 echo "Output was: $GCS_DEST_LIST_JSON"
                 GCS_DEST_LIST_JSON="" # Treat as empty
             fi
-            DEST_UPDATE_JSON=$(echo "$GCS_DEST_LIST_JSON" | jq -r '.[].updated' || echo "")
+            DEST_UPDATE_JSON=$(echo "$GCS_DEST_LIST_JSON" | jq -r '.[].metadata.updated' || echo "")
             
             if [[ -z "$DEST_UPDATE_JSON" ]]; then
               echo "Published songbook for '$edition' not found. Adding to build queue."

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -53,7 +53,14 @@ jobs:
           EDITIONS_TO_BUILD='[]'
           SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
 
-          SOURCE_LATEST_UPDATE_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json | jq -r '.[].updated' | sort -r | head -n 1)
+          GCS_LIST_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json)
+          if [[ $? -ne 0 ]]; then
+              echo "::error::'gcloud storage ls' command failed for source path."
+              echo "Output was: $GCS_LIST_JSON"
+              exit 1
+          fi
+
+          SOURCE_LATEST_UPDATE_JSON=$(echo "$GCS_LIST_JSON" | jq -r '.[].updated' | sort -r | head -n 1)
           if [[ -z "$SOURCE_LATEST_UPDATE_JSON" || "$SOURCE_LATEST_UPDATE_JSON" == "null" ]]; then
             echo "No source files found in cache. Nothing to build."
             echo "editions_to_build=[]" >> $GITHUB_OUTPUT
@@ -64,7 +71,13 @@ jobs:
 
           for edition in $(echo '${{ env.EDITIONS }}' | jq -r '.[]'); do
             DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
-            DEST_UPDATE_JSON=$(gcloud storage ls "$DEST_PATH" --json | jq -r '.[].updated' || echo "")
+            GCS_DEST_LIST_JSON=$(gcloud storage ls "$DEST_PATH" --json)
+            if [[ $? -ne 0 ]]; then
+                echo "::warning::'gcloud storage ls' command failed for destination path ${DEST_PATH}. Assuming it doesn't exist."
+                echo "Output was: $GCS_DEST_LIST_JSON"
+                GCS_DEST_LIST_JSON="" # Treat as empty
+            fi
+            DEST_UPDATE_JSON=$(echo "$GCS_DEST_LIST_JSON" | jq -r '.[].updated' || echo "")
             
             if [[ -z "$DEST_UPDATE_JSON" ]]; then
               echo "Published songbook for '$edition' not found. Adding to build queue."

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -3,8 +3,13 @@ name: Generate Songbook
 on:
   schedule:
     # Run every 10 minutes
-    - cron: '*/10 * * * *'
+    - cron: "*/10 * * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Force regeneration of all songbooks regardless of changes"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -13,7 +18,7 @@ jobs:
   check-for-updates:
     name: Check for updates
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !github.event.inputs.force)
     outputs:
       editions_to_build: ${{ steps.check.outputs.editions_to_build }}
     steps:
@@ -72,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-for-updates
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && fromJson(needs.check-for-updates.outputs.editions_to_build)[0] != null)
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.force) ||
+      (needs.check-for-updates.outputs.editions_to_build != '[]' && needs.check-for-updates.outputs.editions_to_build != '')
     strategy:
       fail-fast: false
       matrix:
-        edition: ${{ github.event_name == 'schedule' && fromJson(needs.check-for-updates.outputs.editions_to_build) || fromJson('["regular", "complete"]') }}
+        edition: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force) && fromJson('["regular", "complete"]') || fromJson(needs.check-for-updates.outputs.editions_to_build) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -105,6 +105,9 @@ jobs:
     name: Generate Songbook (${{ matrix.edition }})
     runs-on: ubuntu-latest
     needs: check-for-updates
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-generate
+      cancel-in-progress: false
     if: needs.check-for-updates.outputs.editions_to_build != '[]' && needs.check-for-updates.outputs.editions_to_build != ''
     strategy:
       fail-fast: false

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -10,13 +10,74 @@ permissions:
   contents: read
 
 jobs:
+  check-for-updates:
+    name: Check for updates
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    outputs:
+      editions_to_build: ${{ steps.check.outputs.editions_to_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Load environment variables
+        uses: falti/dotenv-action@v1.1.4
+        with: { path: .env, export-variables: true, keys-case: bypass }
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with: { credentials_json: '${{ secrets.GCP_SA_KEY }}' }
+      - name: Set up Cloud SDK
+        run: gcloud config set project ${{ env.GCP_PROJECT_ID }}
+      - name: Check GCS modification times
+        id: check
+        run: |
+          EDITIONS_TO_BUILD='[]'
+          SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
+
+          SOURCE_LATEST_UPDATE_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json | jq -r '.[].updated' | sort -r | head -n 1)
+          if [[ -z "$SOURCE_LATEST_UPDATE_JSON" || "$SOURCE_LATEST_UPDATE_JSON" == "null" ]]; then
+            echo "No source files found in cache. Nothing to build."
+            echo "editions_to_build=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          SOURCE_LATEST_UPDATE_TS=$(date -d "$SOURCE_LATEST_UPDATE_JSON" +%s)
+          echo "Latest source file update: $(date -d @$SOURCE_LATEST_UPDATE_TS)"
+
+          for edition in regular complete; do
+            DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
+            DEST_UPDATE_JSON=$(gcloud storage ls "$DEST_PATH" --json | jq -r '.[].updated' || echo "")
+            
+            if [[ -z "$DEST_UPDATE_JSON" ]]; then
+              echo "Published songbook for '$edition' not found. Adding to build queue."
+              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq ". + [\"$edition\"]")
+              continue
+            fi
+            
+            DEST_UPDATE_TS=$(date -d "$DEST_UPDATE_JSON" +%s)
+            echo "Latest '$edition' songbook published at: $(date -d @$DEST_UPDATE_TS)"
+
+            if (( SOURCE_LATEST_UPDATE_TS > DEST_UPDATE_TS )); then
+              echo "Source files are newer than '$edition' songbook. Adding to build queue."
+              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq ". + [\"$edition\"]")
+            else
+              echo "Songbook '$edition' is up to date."
+            fi
+          done
+
+          echo "Editions to build: $EDITIONS_TO_BUILD"
+          echo "editions_to_build=$EDITIONS_TO_BUILD" >> $GITHUB_OUTPUT
+  
   generate-songbook:
     name: Generate Songbook (${{ matrix.edition }})
     runs-on: ubuntu-latest
+    needs: check-for-updates
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && fromJson(needs.check-for-updates.outputs.editions_to_build)[0] != null)
     strategy:
+      fail-fast: false
       matrix:
-        edition: [regular, complete]
-
+        edition: ${{ github.event_name == 'schedule' && fromJson(needs.check-for-updates.outputs.editions_to_build) || fromJson('["regular", "complete"]') }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -36,84 +97,26 @@ jobs:
 
     - name: Set up Cloud SDK
       run: gcloud config set project ${{ env.GCP_PROJECT_ID }}
-
-    - name: Check for recent changes in GCS
-      id: check-changes
-      if: github.event_name == 'schedule'
-      run: |
-        CUTOFF_TIME=$(date -u -d '10 minutes ago' +%s)
-        GCS_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
-
-        echo "Checking for files in $GCS_PATH modified after $(date -u -d @$CUTOFF_TIME +'%Y-%m-%dT%H:%M:%SZ')"
-
-        # Capture the output of gcloud ls to check for errors and empty results
-        GCS_LIST_JSON=$(gcloud storage ls "$GCS_PATH**" --json)
-        if [[ $? -ne 0 ]]; then
-            echo "::error::'gcloud storage ls' command failed."
-            exit 1
-        fi
-
-        # Extract the most recent update timestamp
-        LAST_UPDATED_STR=$(echo "$GCS_LIST_JSON" | jq -r '.[].updated' | sort -r | head -n 1)
-
-        if [[ -z "$LAST_UPDATED_STR" || "$LAST_UPDATED_STR" == "null" ]]; then
-          echo "No files found in GCS bucket or no valid update times. No changes detected."
-          echo "changes_detected=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Convert timestamp to seconds since epoch for comparison
-        LAST_UPDATED_TS=$(date -u -d "$LAST_UPDATED_STR" +%s)
-        if [[ $? -ne 0 ]]; then
-          echo "::error::Failed to parse timestamp '$LAST_UPDATED_STR'."
-          exit 1
-        fi
-
-        if [[ "$LAST_UPDATED_TS" -gt "$CUTOFF_TIME" ]]; then
-          echo "Found recent changes. Last update at $LAST_UPDATED_STR. Proceeding with songbook generation."
-          echo "changes_detected=true" >> $GITHUB_OUTPUT
-        else
-          echo "No recent changes detected. Last update at $LAST_UPDATED_STR."
-          echo "changes_detected=false" >> $GITHUB_OUTPUT
-        fi
-
+      
     - name: Trigger songbook generation
-      if: github.event_name == 'workflow_dispatch' || steps.check-changes.outputs.changes_detected == 'true'
       run: |
-        # Prepare the payload for the API using the matrix edition
-        PAYLOAD=$(jq -n \
-          --arg edition "${{ matrix.edition }}" \
-          '{
-            edition: $edition
-          }')
-
+        PAYLOAD=$(jq -n --arg edition "${{ matrix.edition }}" '{ edition: $edition }')
         echo "Triggering songbook generation with payload: $PAYLOAD"
-
-        # Get the API endpoint URL
         API_URL="https://${{ env.GCP_REGION }}-${{ env.GCP_PROJECT_ID }}.cloudfunctions.net/${{ env.API_FUNCTION_NAME }}"
-
-        # Trigger the job
-        RESPONSE=$(curl -s -X POST \
-          -H "Content-Type: application/json" \
-          -d "$PAYLOAD" \
-          "$API_URL")
-
+        
+        RESPONSE=$(curl -s -f -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$API_URL")
         echo "API Response: $RESPONSE"
-
-        # Extract job ID
         JOB_ID=$(echo "$RESPONSE" | jq -r '.job_id')
 
         if [[ "$JOB_ID" == "null" || -z "$JOB_ID" ]]; then
           echo "Failed to create job"
           exit 1
         fi
-
         echo "Created job with ID: $JOB_ID"
 
-        # Poll for completion (with timeout)
-        TIMEOUT=120  # 2 minutes
+        TIMEOUT=120
         ELAPSED=0
-        POLL_INTERVAL=1  # seconds
+        POLL_INTERVAL=1
 
         while [[ $ELAPSED -lt $TIMEOUT ]]; do
           sleep $POLL_INTERVAL
@@ -123,8 +126,6 @@ jobs:
           STATUS=$(echo "$STATUS_RESPONSE" | jq -r '.status')
           PROGRESS=$(echo "$STATUS_RESPONSE" | jq -r '.progress // 0')
           MESSAGE=$(echo "$STATUS_RESPONSE" | jq -r '.last_message // ""')
-
-          # Convert progress to percentage and round up
           PROGRESS_PERCENT=$(echo "$PROGRESS * 100" | bc -l | awk '{printf "%.0f", $1 + 0.5}')
 
           echo "[$ELAPSED/${TIMEOUT}s] Status: $STATUS, Progress: ${PROGRESS_PERCENT}%, Message: $MESSAGE"
@@ -133,7 +134,6 @@ jobs:
             echo "✅ Songbook generation completed successfully!"
             SOURCE_GCS_PATH="gs://${GCS_CDN_BUCKET}/${JOB_ID}/songbook.pdf"
             DEST_GCS_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${{ matrix.edition }}.pdf"
-
             echo "Uploading to public bucket: ${DEST_GCS_PATH}"
             gcloud storage cp "${SOURCE_GCS_PATH}" "${DEST_GCS_PATH}"
             echo "✅ Successfully uploaded to ${DEST_GCS_PATH}"

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -21,7 +21,6 @@ jobs:
   check-for-updates:
     name: Check for updates
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !github.event.inputs.force)
     outputs:
       editions_to_build: ${{ steps.check.outputs.editions_to_build }}
     steps:
@@ -39,6 +38,13 @@ jobs:
       - name: Check GCS modification times
         id: check
         run: |
+          # If 'force' is used, build all editions
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
+            echo "Force mode enabled. Building all editions."
+            echo "editions_to_build=${{ env.EDITIONS }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           EDITIONS_TO_BUILD='[]'
           SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
 
@@ -79,13 +85,11 @@ jobs:
     name: Generate Songbook (${{ matrix.edition }})
     runs-on: ubuntu-latest
     needs: check-for-updates
-    if: |
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.force) ||
-      (needs.check-for-updates.outputs.editions_to_build != '[]' && needs.check-for-updates.outputs.editions_to_build != '')
+    if: needs.check-for-updates.outputs.editions_to_build != '[]' && needs.check-for-updates.outputs.editions_to_build != ''
     strategy:
       fail-fast: false
       matrix:
-        edition: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force) && fromJson(env.EDITIONS) || fromJson(needs.check-for-updates.outputs.editions_to_build) }}
+        edition: ${{ fromJson(needs.check-for-updates.outputs.editions_to_build) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-for-updates
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-generate
+      group: ${{ github.workflow }}-generate
       cancel-in-progress: false
     if: needs.check-for-updates.outputs.editions_to_build != '[]' && needs.check-for-updates.outputs.editions_to_build != ''
     strategy:

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -50,7 +50,7 @@ jobs:
             exit 0
           fi
 
-          EDITIONS_TO_BUILD='[]'
+          EDITIONS_TO_BUILD_STR=""
           SOURCE_PATH="gs://${GCS_WORKER_CACHE_BUCKET}/song-sheets/"
 
           GCS_LIST_JSON=$(gcloud storage ls "$SOURCE_PATH**" --json)
@@ -81,7 +81,7 @@ jobs:
             
             if [[ -z "$DEST_UPDATE_JSON" ]]; then
               echo "Published songbook for '$edition' not found. Adding to build queue."
-              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq -c ". + [\"$edition\"]")
+              EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
               continue
             fi
             
@@ -90,14 +90,17 @@ jobs:
 
             if (( SOURCE_LATEST_UPDATE_TS > DEST_UPDATE_TS )); then
               echo "Source files are newer than '$edition' songbook. Adding to build queue."
-              EDITIONS_TO_BUILD=$(echo "$EDITIONS_TO_BUILD" | jq -c ". + [\"$edition\"]")
+              EDITIONS_TO_BUILD_STR="${EDITIONS_TO_BUILD_STR} ${edition}"
             else
               echo "Songbook '$edition' is up to date."
             fi
           done
 
-          echo "Editions to build: $EDITIONS_TO_BUILD"
-          echo "editions_to_build=$EDITIONS_TO_BUILD" >> $GITHUB_OUTPUT
+          # Convert the space-separated string to a JSON array for the output
+          FINAL_EDITIONS_JSON=$(echo "${EDITIONS_TO_BUILD_STR}" | jq -R 'split(" ") | map(select(length > 0))' | jq -c '.')
+
+          echo "Editions to build: $FINAL_EDITIONS_JSON"
+          echo "editions_to_build=$FINAL_EDITIONS_JSON" >> $GITHUB_OUTPUT
   
   generate-songbook:
     name: Generate Songbook (${{ matrix.edition }})

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Check GCS modification times
         id: check
         run: |
+          set -x
           # If 'force' is used, build all editions
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.force }}" == "true" ]]; then
             echo "Force mode enabled. Building all editions."

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  EDITIONS: '["regular", "complete"]'
+
 jobs:
   check-for-updates:
     name: Check for updates
@@ -48,7 +51,7 @@ jobs:
           SOURCE_LATEST_UPDATE_TS=$(date -d "$SOURCE_LATEST_UPDATE_JSON" +%s)
           echo "Latest source file update: $(date -d @$SOURCE_LATEST_UPDATE_TS)"
 
-          for edition in regular complete; do
+          for edition in $(echo '${{ env.EDITIONS }}' | jq -r '.[]'); do
             DEST_PATH="gs://${GCS_SONGBOOKS_BUCKET}/${edition}.pdf"
             DEST_UPDATE_JSON=$(gcloud storage ls "$DEST_PATH" --json | jq -r '.[].updated' || echo "")
             
@@ -82,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        edition: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force) && fromJson('["regular", "complete"]') || fromJson(needs.check-for-updates.outputs.editions_to_build) }}
+        edition: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force) && fromJson(env.EDITIONS) || fromJson(needs.check-for-updates.outputs.editions_to_build) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -28,11 +28,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Load environment variables
         uses: falti/dotenv-action@v1.1.4
-        with: { path: .env, export-variables: true, keys-case: bypass }
+        with:
+          path: .env
+          export-variables: true
+          keys-case: bypass
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2
-        with: { credentials_json: '${{ secrets.GCP_SA_KEY }}' }
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
       - name: Set up Cloud SDK
         run: gcloud config set project ${{ env.GCP_PROJECT_ID }}
       - name: Check GCS modification times

--- a/deploy-gcs.sh
+++ b/deploy-gcs.sh
@@ -119,6 +119,9 @@ gsutil iam ch \
 gsutil iam ch \
   "serviceAccount:${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}:objectAdmin" \
   "gs://${GCS_SONGBOOKS_BUCKET}"
+gsutil iam ch \
+  "serviceAccount:cloud-run-deployer@${GCP_PROJECT_ID}.iam.gserviceaccount.com:objectAdmin" \
+  "gs://${GCS_SONGBOOKS_BUCKET}"
 
 echo "7. (Optional) Grant Service Account Token Creator for push subscriptions…"
 gcloud iam service-accounts add-iam-policy-binding "${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}" \

--- a/deploy-gcs.sh
+++ b/deploy-gcs.sh
@@ -107,7 +107,7 @@ gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
 
 # Storage: allow uploading objects to CDN bucket
 gsutil iam ch \
-  "serviceAccount:${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}:objectCreator" \
+  "serviceAccount:${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}:objectAdmin" \
   "gs://${GCS_CDN_BUCKET}"
 
 # Storage: allow uploading objects to worker cache bucket
@@ -117,7 +117,7 @@ gsutil iam ch \
 
 # Storage: allow uploading objects to songbooks bucket
 gsutil iam ch \
-  "serviceAccount:${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}:objectCreator" \
+  "serviceAccount:${SONGBOOK_GENERATOR_SERVICE_ACCOUNT}:objectAdmin" \
   "gs://${GCS_SONGBOOKS_BUCKET}"
 
 echo "7. (Optional) Grant Service Account Token Creator for push subscriptions…"


### PR DESCRIPTION
Grant objectAdmin role to deployer, so Github actions can update songbooks

Separate schedule job into check-for-updates and the actual generate-songbook jobs.
Make it properly detect when it needs to regenerate, based on last update time of published songbooks.

Though keep a force flag to force regeneration.