### PR TITLE
Remove pre-commit checks step from workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,6 +40,3 @@ jobs:
 
       - name: Install pre-commit hooks
         run: uvx --from 'pre-commit<5' pre-commit install
-
-      - name: Run pre-commit checks
-        run: uvx --from 'pre-commit<5' pre-commit run --all-files


### PR DESCRIPTION
This step prevents copilot from starting if it accidentally convinced itself to commit bypassing the pre commit checks during a previous session. 