### PR TITLE
Halloween: add support for toc postfix annotations

### DIFF
--- a/generator/common/config.py
+++ b/generator/common/config.py
@@ -52,7 +52,7 @@ class Toc(BaseModel):
     text_fontsize: float = 10.0
     title_font: str = "RobotoCondensed-Bold.ttf"
     title_fontsize: int = 16
-    max_toc_entry_length: int = 60
+    max_toc_entry_length: int = 48
     include_difficulty: bool = True
     include_wip_marker: bool = True
     postfixes: Optional[List[TocPostfix]] = None

--- a/generator/common/config.py
+++ b/generator/common/config.py
@@ -30,6 +30,13 @@ class Cover(BaseModel):
     file_id: Optional[str] = "1rxn4Kl6fe-SUFqfYieb5FrxkVwHLLVPbwOXtWRGc740"
 
 
+class TocPostfix(BaseModel):
+    """Configuration for a single TOC entry postfix."""
+
+    postfix: str
+    filters: List[Union[FilterGroup, PropertyFilter]]
+
+
 class Toc(BaseModel):
     columns_per_page: int = 2
     column_width: int = 250
@@ -48,6 +55,7 @@ class Toc(BaseModel):
     max_toc_entry_length: int = 60
     include_difficulty: bool = True
     include_wip_marker: bool = True
+    postfixes: Optional[List[TocPostfix]] = None
 
     @field_validator(
         "*",

--- a/generator/common/config.py
+++ b/generator/common/config.py
@@ -52,7 +52,7 @@ class Toc(BaseModel):
     text_fontsize: float = 10.0
     title_font: str = "RobotoCondensed-Bold.ttf"
     title_fontsize: int = 16
-    max_toc_entry_length: int = 48
+    max_toc_entry_length: int = 52
     include_difficulty: bool = True
     include_wip_marker: bool = True
     postfixes: Optional[List[TocPostfix]] = None

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -28,6 +28,13 @@
         - key: "status"
           operator: "equals"
           value: "APPROVED"
+  table_of_contents:
+    postfixes:
+      - postfix: " 🎃"
+        filters:
+          - key: "specialbooks"
+            operator: "contains"
+            value: "halloween"
 
 - id: "ukulele-hooley-2025"
   title: "Ukulele Hooley 2025"
@@ -48,18 +55,3 @@
     - key: "specialbooks"
       operator: "contains"
       value: "hooley-2025"
-
-- id: "halloween"
-  title: "Ukulele Tuesday - Halloween Songbook"
-  description: "A spooky collection of Halloween-themed songs."
-  filters:
-    - key: "specialbooks"
-      operator: "contains"
-      value: "halloween"
-  table_of_contents:
-    postfixes:
-      - postfix: " 🎃"
-        filters:
-          - key: "tags"
-            operator: "contains"
-            value: "halloween"

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -48,3 +48,18 @@
     - key: "specialbooks"
       operator: "contains"
       value: "hooley-2025"
+
+- id: "halloween"
+  title: "Ukulele Tuesday - Halloween Songbook"
+  description: "A spooky collection of Halloween-themed songs."
+  filters:
+    - key: "specialbooks"
+      operator: "contains"
+      value: "halloween"
+  table_of_contents:
+    postfixes:
+      - postfix: " 🎃"
+        filters:
+          - key: "tags"
+            operator: "contains"
+            value: "halloween"

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -6,7 +6,7 @@
 
     We rotate the songs we play on Tuesday sessions frequently,
     so make sure to download the latest version!
-  cover_file_id: "1rxn4Kl6fe-SUFqfYieb5FrxkVwHLLVPbwOXtWRGc740"
+  cover_file_id: "1umElTLlai9GX6Ycp5BTlxb2M3g4ZePxyJYNY4n6fXtg"
   preface_file_ids:
     - "1ZxYst-xswtkO6ZSU7tiPKKDoYwvBRWo-ag2tyu6fO2w"
   filters:

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -14,6 +14,7 @@
       operator: "contains"
       value: "regular"
   table_of_contents:
+    # Include a pumpkin for songs tagged as `halloween`
     postfixes:
       - postfix: " 🎃"
         filters:

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -13,6 +13,13 @@
     - key: "specialbooks"
       operator: "contains"
       value: "regular"
+  table_of_contents:
+    postfixes:
+      - postfix: " 🎃"
+        filters:
+          - key: "specialbooks"
+            operator: "contains"
+            value: "halloween"
 
 - id: "complete"
   title: "Ukulele Tuesday - Complete Songbook"
@@ -28,13 +35,6 @@
         - key: "status"
           operator: "equals"
           value: "APPROVED"
-  table_of_contents:
-    postfixes:
-      - postfix: " 🎃"
-        filters:
-          - key: "specialbooks"
-            operator: "contains"
-            value: "halloween"
 
 - id: "ukulele-hooley-2025"
   title: "Ukulele Hooley 2025"

--- a/generator/config/songbooks.yaml
+++ b/generator/config/songbooks.yaml
@@ -55,3 +55,12 @@
     - key: "specialbooks"
       operator: "contains"
       value: "hooley-2025"
+
+- id: "halloween"
+  title: "Ukulele Tuesday - Halloween Songbook"
+  description: "A spooky collection of Halloween-themed songs."
+  cover_file_id: "1kHu08P8LWRx5W6zyZTo9JFZgyiq_aTsjrg51rqMZUDI"
+  filters:
+    - key: "specialbooks"
+      operator: "contains"
+      value: "halloween"

--- a/generator/worker/test_toc.py
+++ b/generator/worker/test_toc.py
@@ -7,6 +7,7 @@ from .toc import (
 )
 from .models import File
 from . import toc
+from ..common.config import TocPostfix
 
 
 @pytest.mark.parametrize(
@@ -272,7 +273,7 @@ def test_add_toc_entry_with_postfix(mock_toc_generator, mocker):
     # Mock filter logic
     mock_filter = mocker.MagicMock()
     mock_filter.matches.return_value = True
-    postfix_config = toc.TocPostfix(postfix=" 🎃", filters=[mock_filter])
+    postfix_config = TocPostfix(postfix=" 🎃", filters=[mock_filter])
     generator.config.postfixes = [postfix_config]
 
     file = File(id="1", name="Monster Mash", properties={"tags": "halloween"})
@@ -299,7 +300,7 @@ def test_add_toc_entry_with_postfix_no_match(mock_toc_generator, mocker):
     # Mock filter logic
     mock_filter = mocker.MagicMock()
     mock_filter.matches.return_value = False
-    postfix_config = toc.TocPostfix(postfix=" 🎃", filters=[mock_filter])
+    postfix_config = TocPostfix(postfix=" 🎃", filters=[mock_filter])
     generator.config.postfixes = [postfix_config]
 
     file = File(id="1", name="Jingle Bells", properties={"tags": "christmas"})

--- a/generator/worker/test_toc.py
+++ b/generator/worker/test_toc.py
@@ -264,6 +264,61 @@ def test_add_toc_entry_ready_to_play_status(mock_toc_generator):
     assert "Ready Song*" in appended_title
 
 
+def test_add_toc_entry_with_postfix(mock_toc_generator, mocker):
+    """Test that a postfix is added to the TOC entry when filters match."""
+    generator = mock_toc_generator
+    mock_tw = MagicMock(spec=fitz.TextWriter)
+
+    # Mock filter logic
+    mock_filter = mocker.MagicMock()
+    mock_filter.matches.return_value = True
+    postfix_config = toc.TocPostfix(postfix=" 🎃", filters=[mock_filter])
+    generator.config.postfixes = [postfix_config]
+
+    file = File(id="1", name="Monster Mash", properties={"tags": "halloween"})
+
+    generator._add_toc_entry(
+        tw=mock_tw,
+        file_index=0,
+        page_offset=0,
+        file=file,
+        x_start=25,
+        y_pos=70,
+        current_page_index=0,
+    )
+
+    appended_title = mock_tw.append.call_args_list[0].args[1]
+    assert "Monster Mash 🎃" in appended_title
+
+
+def test_add_toc_entry_with_postfix_no_match(mock_toc_generator, mocker):
+    """Test that a postfix is NOT added to the TOC entry if filters don't match."""
+    generator = mock_toc_generator
+    mock_tw = MagicMock(spec=fitz.TextWriter)
+
+    # Mock filter logic
+    mock_filter = mocker.MagicMock()
+    mock_filter.matches.return_value = False
+    postfix_config = toc.TocPostfix(postfix=" 🎃", filters=[mock_filter])
+    generator.config.postfixes = [postfix_config]
+
+    file = File(id="1", name="Jingle Bells", properties={"tags": "christmas"})
+
+    generator._add_toc_entry(
+        tw=mock_tw,
+        file_index=0,
+        page_offset=0,
+        file=file,
+        x_start=25,
+        y_pos=70,
+        current_page_index=0,
+    )
+
+    appended_title = mock_tw.append.call_args_list[0].args[1]
+    assert "Jingle Bells" in appended_title
+    assert "🎃" not in appended_title
+
+
 def test_add_toc_entry_ready_to_play_status_marker_disabled(mock_toc_generator):
     """Test that a '*' is NOT added for READY_TO_PLAY if setting is false."""
     generator = mock_toc_generator

--- a/generator/worker/test_toc.py
+++ b/generator/worker/test_toc.py
@@ -8,6 +8,7 @@ from .toc import (
 from .models import File
 from . import toc
 from ..common.config import TocPostfix
+from ..common.filters import PropertyFilter
 
 
 @pytest.mark.parametrize(
@@ -271,7 +272,7 @@ def test_add_toc_entry_with_postfix(mock_toc_generator, mocker):
     mock_tw = MagicMock(spec=fitz.TextWriter)
 
     # Mock filter logic
-    mock_filter = mocker.MagicMock()
+    mock_filter = mocker.MagicMock(spec=PropertyFilter)
     mock_filter.matches.return_value = True
     postfix_config = TocPostfix(postfix=" 🎃", filters=[mock_filter])
     generator.config.postfixes = [postfix_config]
@@ -298,7 +299,7 @@ def test_add_toc_entry_with_postfix_no_match(mock_toc_generator, mocker):
     mock_tw = MagicMock(spec=fitz.TextWriter)
 
     # Mock filter logic
-    mock_filter = mocker.MagicMock()
+    mock_filter = mocker.MagicMock(spec=PropertyFilter)
     mock_filter.matches.return_value = False
     postfix_config = TocPostfix(postfix=" 🎃", filters=[mock_filter])
     generator.config.postfixes = [postfix_config]

--- a/generator/worker/toc.py
+++ b/generator/worker/toc.py
@@ -100,7 +100,16 @@ class TocGenerator:
             is_ready_to_play=file.properties.get("status") == "READY_TO_PLAY",
         )
 
-        full_title = f"{symbol}{shortened_title}"
+        # Add any custom postfixes
+        postfix_str = ""
+        if self.config.postfixes:
+            for postfix_config in self.config.postfixes:
+                for p_filter in postfix_config.filters:
+                    if p_filter.matches(file.properties):
+                        postfix_str += postfix_config.postfix
+                        break  # Stop checking filters for this postfix config
+
+        full_title = f"{symbol}{shortened_title}{postfix_str}"
 
         # Append title
         tw.append(

--- a/generator/worker/toc.py
+++ b/generator/worker/toc.py
@@ -94,12 +94,6 @@ class TocGenerator:
                 except (ValueError, TypeError):
                     pass  # Ignore if not a valid integer
 
-        shortened_title = self._generate_toc_title(
-            file.name,
-            max_length=self.config.max_toc_entry_length,
-            is_ready_to_play=file.properties.get("status") == "READY_TO_PLAY",
-        )
-
         # Add any custom postfixes
         postfix_str = ""
         if self.config.postfixes:
@@ -108,6 +102,12 @@ class TocGenerator:
                     if p_filter.matches(file.properties):
                         postfix_str += postfix_config.postfix
                         break  # Stop checking filters for this postfix config
+
+        shortened_title = self._generate_toc_title(
+            file.name,
+            max_length=self.config.max_toc_entry_length - len(postfix_str),
+            is_ready_to_play=file.properties.get("status") == "READY_TO_PLAY",
+        )
 
         full_title = f"{symbol}{shortened_title}{postfix_str}"
 


### PR DESCRIPTION
Halloween songs prep:
* Add support for postfix annotations in toc (songs with tagged a halloween have a  🎃 icon)
* Change the cover to first halloweeny cover
* Add dedicated halloween songbook in the config to generate a songbook with only halloween tunes (not published yet)
* Tweak max toc title length entry config